### PR TITLE
Alternative stack graph resolution functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +38,12 @@ checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56fc6cf8dc8c4158eed8649f9b8b0ea1518eb62b544fe9490d66fa0b349eafe9"
 
 [[package]]
 name = "android_system_properties"
@@ -212,6 +229,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "109c1ca6e6b7f82cc233a97004ea8ed7ca123a9af07a8230878fcfda9b158bf0"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "derivative"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +318,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
+name = "enumset"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
+dependencies = [
+ "enumset_derive",
+]
+
+[[package]]
+name = "enumset_derive"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -317,6 +401,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash 0.8.3",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
+dependencies = [
+ "hashbrown 0.14.0",
+]
+
+[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,6 +448,12 @@ dependencies = [
  "cxx",
  "cxx-build",
 ]
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "indexmap"
@@ -412,6 +521,17 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -483,11 +603,11 @@ dependencies = [
 
 [[package]]
 name = "lsp-positions"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce95baee2c4668ed42b67ae7f931abe06169fcef8e853815ffaf53b56ac7f0c"
+version = "0.3.2"
+source = "git+https://github.com/github/stack-graphs?branch=skullian#43e0d2993a865ceb37b5607d3cdc5476473e1fb1"
 dependencies = [
  "memchr",
+ "serde",
  "tree-sitter",
  "unicode-segmentation",
 ]
@@ -572,6 +692,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4b27ab7be369122c218afc2079489cdcb4b517c0a3fc386ff11e1fedfcc2b35"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
 name = "portable-atomic"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -637,6 +769,42 @@ name = "regex-syntax"
 version = "0.6.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+
+[[package]]
+name = "rmp"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44519172358fd6d58656c86ab8e7fbc9e1490c3e8f14d35ed78ca0dd07403c9f"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5b13be192e0220b8afb7222aa5813cb62cc269ebb5cac346ca6487681d2913e"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e213bc3ecb39ac32e81e51ebe31fd888a940515173e3a18a35f8c6e896422a"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
 
 [[package]]
 name = "rust-ini"
@@ -761,17 +929,20 @@ checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
 
 [[package]]
 name = "stack-graphs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcec708e6d05ff78212b37b826ec435e7204abae9d0a3548077ac617fb762fe7"
+version = "0.11.0"
+source = "git+https://github.com/github/stack-graphs?branch=skullian#43e0d2993a865ceb37b5607d3cdc5476473e1fb1"
 dependencies = [
  "bitvec",
  "controlled-option",
  "either",
+ "enumset",
  "fxhash",
  "itertools",
  "libc",
  "lsp-positions",
+ "rmp-serde",
+ "rusqlite",
+ "serde",
  "smallvec",
  "thiserror",
 ]
@@ -902,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-graph"
-version = "0.7.0"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "639d21e886f581d293de5f5081f09af003c54607ff3fa85efa159b243ba1f97a"
+checksum = "a63b3eb31f00bcda8431d635b143a05f34f9935293cfe463365afd72ffedbe76"
 dependencies = [
  "log",
  "regex",
@@ -978,16 +1149,15 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-stack-graphs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94bed6a4b96eb18c57ecc7fffd7389c695bb7146d969a3b992d00a20f8ee3b54"
+version = "0.7.0"
+source = "git+https://github.com/github/stack-graphs?branch=skullian#43e0d2993a865ceb37b5607d3cdc5476473e1fb1"
 dependencies = [
  "anyhow",
  "controlled-option",
  "itertools",
- "lazy_static",
  "log",
  "lsp-positions",
+ "once_cell",
  "regex",
  "rust-ini",
  "stack-graphs",
@@ -1044,6 +1214,12 @@ checksum = "e0a303d30665362d9680d7d91d78b23f5f899504d4f08b3c4cf08d055d87c0ad"
 dependencies = [
  "destructure_traitobject",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ tree-sitter-c="*"
 tree-sitter-cpp="*"
 tree-sitter-rust="*"
 tree-sitter-python="*"
-stack-graphs="*"
+stack-graphs={ version = "*", features = ["storage"] }
 tree-sitter-stack-graphs="*"
 argparse="*"
 walkdir="*"
@@ -30,3 +30,7 @@ serde="*"
 serde_yaml="*"
 smallvec = "*"
 time = ">=0.2.23"
+
+[patch.crates-io]
+stack-graphs = { git = "https://github.com/github/stack-graphs", branch = "skullian" }
+tree-sitter-stack-graphs = { git = "https://github.com/github/stack-graphs", branch = "skullian" }

--- a/assets/tsg/java.tsg.alt
+++ b/assets/tsg/java.tsg.alt
@@ -160,7 +160,7 @@ attribute refkind = kind                => debug_refkind = kind
   node @this.push_start
 }
 
-(program)@this {
+(program)@_this {
   ;; edge @this.scope -> @this.pop_start
 }
 
@@ -229,7 +229,7 @@ attribute refkind = kind                => debug_refkind = kind
   edge @this.pop_start -> @name.pop_start
 }
 
-(package_declaration (_)@name)@this {
+(package_declaration (_)@_name)@_this {
   ;; edge @name.scope -> @this.scope
 }
 
@@ -335,13 +335,13 @@ attribute refkind = kind                => debug_refkind = kind
 }
 
 [
-  (method_declaration type: (_)@type name: (_)@name)@this
-  (field_declaration type: (_)@type declarator: (variable_declarator name: (_)@name))@this
-  (constant_declaration type: (_)@type declarator: (variable_declarator name: (_)@name))@this
-  (local_variable_declaration type: (_)@type declarator: (variable_declarator name: (_)@name))@this
-  (formal_parameter type: (_)@type name: (_)@name)@this
-  (catch_formal_parameter (_)@type name: (_)@name .)@this
-  (annotation_type_element_declaration type: (_)@type name: (_)@name)@this
+  (method_declaration type: (_)@type name: (_)@name)@_this
+  (field_declaration type: (_)@type declarator: (variable_declarator name: (_)@name))@_this
+  (constant_declaration type: (_)@type declarator: (variable_declarator name: (_)@name))@_this
+  (local_variable_declaration type: (_)@type declarator: (variable_declarator name: (_)@name))@_this
+  (formal_parameter type: (_)@type name: (_)@name)@_this
+  (catch_formal_parameter (_)@type name: (_)@name .)@_this
+  (annotation_type_element_declaration type: (_)@type name: (_)@name)@_this
 ] {
   edge @name.pop_end -> @type.push_start
 }
@@ -432,7 +432,7 @@ attribute refkind = kind                => debug_refkind = kind
   (import_declaration
     . (_)@name
   )@this
-)@parent {
+)@_parent {
   node @this.scope
   attr (@name.push_start) is_reference, refkind = "includes"
   let @this.pop_end = (node)
@@ -475,91 +475,91 @@ attribute refkind = kind                => debug_refkind = kind
 ;; classes
 (class_declaration
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "class"
 }
 
 ;; interfaces
 (interface_declaration
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "interface"
 }
 
 ;; enums
 (enum_declaration
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "enum"
 }
 
 ;; annotations
 (annotation_type_declaration
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "annotation"
 }
 
 ;; methods
 (method_declaration
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "function"
 }
 
 ;; constructor
 (constructor_declaration
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "function"
 }
 
 ;; fields
 (field_declaration
   declarator: (variable_declarator name: (_)@name)
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "attribute"
 }
 
 ;; constants
 (constant_declaration
   declarator: (variable_declarator name: (_)@name)
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "constant"
 }
 
 ;; annotation_elements
 (annotation_type_element_declaration
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "annotationElement"
 }
 
 ;; parameters
 (catch_formal_parameter
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "parameter"
 }
 
 ;; parameters
 (formal_parameter
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "parameter"
 }
 
 ;; local_variable_declaration
 (local_variable_declaration
   declarator: (variable_declarator name: (_)@name)
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "attribute"
 }
 
 ;; enum_constant
 (enum_constant
   name: (_)@name
-)@this {
+)@_this {
   attr (@name.pop_end) defkind = "enumVariant"
 }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,4 +1,4 @@
 pub mod ts;
 pub mod sg;
 pub mod dg;
-pub mod lavatrice;
+// pub mod lavatrice;


### PR DESCRIPTION
This PR tries some different stack graph resolution functions to see if that improves performance.

_I have changed the `stack-graphs` and `tree-sitter-stack-graphs` dependencies to depend on a special `skullian` branch that includes some fixes that are not released yet! Because of this, I had to disable some code that was using old data structures that have been removed since the version you were using._

Results:

- Two new resolution functions: (1) `resolve_all_paths_reference_by_reference` and (2) `resolve_all_paths_with_partial_paths`.
- Both result in much better performance for the "trivial" benchmark, both in memory use and speed, but (1) seems the fastest actually.
- For the JUnit benchmark, memory behavior seems much better with both of these, but both are very slow. Much slower than I would expect, and it looks like individual references sometimes take really long---much longer than other references. I would have to do some more debugging to see if I can figure out why that is, though.